### PR TITLE
Added rlwrap to packages for Barry

### DIFF
--- a/bash_tools.txt
+++ b/bash_tools.txt
@@ -16,6 +16,7 @@ APT_PACKAGES=(
 	'neo4j'
 	'nginx'
 	'remmina'
+	'rlwrap'
 	'rpm2cpio'
 	'seclists'
 	'smbmap'


### PR DESCRIPTION
- Replaced incorrect package for xfree, added neo4j
- Un-commented c2_sliver and added debug variable
- BIG change. - Standardized output with print_message - run_and_log function to execute commands and log output - debug output - package management commands wrapped in subproc and stdout and stderr   logged
- Added rlwrap for Barry
