### PR TITLE
Adding `ipcalc` and `ipcalc-ng` subnet calculators

### DIFF
--- a/bash_tools.txt
+++ b/bash_tools.txt
@@ -11,6 +11,8 @@ APT_PACKAGES=(
 	'golang-go'
 	'hollywood'
 	'htop'
+	'ipcalc'
+	'ipcalc-ng'
 	'jxplorer'
 	'metasploit-framework'
 	'neo4j'


### PR DESCRIPTION
`ipcalc` and `ipcalc-ng` are convenient utilities for calculating subnets, no internet connection required.